### PR TITLE
I am sorry that I am converting your script obviously meant to solve one problem into an actual program :)

### DIFF
--- a/spf_dump.py
+++ b/spf_dump.py
@@ -46,7 +46,12 @@ def parse(domain,depth=0,debug=False):
                 ranges.append(value)
                 if debug: print "Found ip4 [%s]"%value
             elif "ip6" == key:
-                ranges.append(value)
+                if '-p' in sys.argv:
+                    # mangle for postfix $mynetworks
+                    splitvalue = value.split('/')
+                    ranges.append('[{0}]/{1}'.format(splitvalue[0],splitvalue[1]))
+                else:
+                    ranges.append(value)
                 if debug: print "Found ip6 [%s]"%value
             elif "include" == key or "redirect" == key:
                 if depth < MAX_DEPTH:
@@ -74,5 +79,12 @@ def parse(domain,depth=0,debug=False):
 
     return list(set(ranges))
 
-for i in parse(sys.argv[1]):
-    print i
+if __name__ == '__main__':
+    parsed = []
+    for arg in sys.argv:
+        if not arg.startswith('-'):
+            parsed.extend(parse(arg,debug=False if '-v' not in sys.argv else True))
+
+    for r in set(parsed):
+        print r
+   


### PR DESCRIPTION
- adds -p argument which formats ipv6 addresses for use in postfix $mynetworks settings (encapsulate address in []s)
- adds -v option which turns debug mode on (off by default)
- converts the straight script into one with a **main** entrypoint, so it can be used as a submodule in other scripts.
- adds support for arbitrary numbers of domains to check in one invocation, e.g. `python spf_dump.py _spf.google.com _spf.facebook.com twitter.com` with or without -p or -v

BUG?: facebook as of this commit has a broken spf record that produces a blank line due to a " " placed in the middle of a key: i" "p4:66.220.157.0/25. I have opted to email postmaster@facebook.com and hope they fix it rather than add even more complexity to deal with this broken record.
